### PR TITLE
Fix some errors in install process

### DIFF
--- a/packages/jobs/src/Commands/InstallCommand.php
+++ b/packages/jobs/src/Commands/InstallCommand.php
@@ -190,8 +190,6 @@ class InstallCommand extends Command
             $pattern = '/->plugins\(\[([\s\S]*?)\]\);/';
             $newPlugins = '';
 
-            var_dump($pluginsToAdd);
-
             foreach ($pluginsToAdd as $plugin) {
                 $searchPlugin = '/' . $plugin . '/';
                 if (preg_match($searchPlugin, $content)) {


### PR DESCRIPTION
Symfony\Component\Finder\Exception\DirectoryNotFoundException

  The "/XYZ/app/Providers\Filament" directory does not exist.

  at vendor/symfony/finder/Finder.php:649
    645▕             } elseif ($glob = glob($dir, (\defined('GLOB_BRACE') ? \GLOB_BRACE : 0) | \GLOB_ONLYDIR | \GLOB_NOSORT)) {
    646▕                 sort($glob);
    647▕                 $resolvedDirs[] = array_map($this->normalizeDir(...), $glob);
    648▕             } else {
  ➜ 649▕                 throw new DirectoryNotFoundException(sprintf('The "%s" directory does not exist.', $dir));
    650▕             }
    651▕         }
    652▕
    653▕         $this->dirs = array_merge($this->dirs, ...$resolvedDirs);

      +16 vendor frames

  17  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))

Thats caused by string vs array return and file path ('/' vs '\').