### PR TITLE
fix invoice package view cache failure on deploy

### DIFF
--- a/packages/invoice/src/InvoiceServiceProvider.php
+++ b/packages/invoice/src/InvoiceServiceProvider.php
@@ -14,8 +14,6 @@ class InvoiceServiceProvider extends MooxServiceProvider
         $package
             ->name('invoice')
             ->hasConfigFile()
-            ->hasViews()
-            ->hasTranslations()
             ->hasMigrations([
                 'create_invoices_table',
                 'create_invoice_lines_table',


### PR DESCRIPTION
## Summary

- Remove unused `hasViews()` and `hasTranslations()` from `moox/invoice` service provider
- The invoice package ships no Blade views or lang files, but still registered those paths
- `php artisan view:cache` during Forge deployment failed with: `packages/invoice/resources/views directory does not exist`
