### PR TITLE
Fix/data import separate swiss german

### DIFF
--- a/packages/data/config/rest-countries.php
+++ b/packages/data/config/rest-countries.php
@@ -43,4 +43,20 @@ return [
     */
 
     'page_limit' => (int) env('REST_COUNTRIES_PAGE_LIMIT', 100),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Separate Language Codes
+    |--------------------------------------------------------------------------
+    |
+    | ISO 639-3 codes listed here are imported as their own static_languages row
+    | instead of being collapsed into a parent ISO 639-1 code. For example, gsw
+    | (Swiss German) is kept separate from de (German) so both appear in the
+    | Languages admin.
+    |
+    */
+
+    'separate_language_codes' => [
+        'gsw',
+    ],
 ];

--- a/packages/data/src/Jobs/ImportStaticDataJob.php
+++ b/packages/data/src/Jobs/ImportStaticDataJob.php
@@ -64,7 +64,6 @@ class ImportStaticDataJob implements ShouldQueue
             'glg' => 'gl', // Galician
             'glv' => 'gv', // Manx
             'grn' => 'gn', // Guarani
-            'gsw' => 'de', // Swiss German (maps to German)
             'hat' => 'ht', // Haitian Creole
             'heb' => 'he', // Hebrew
             'her' => 'hz', // Herero
@@ -191,11 +190,12 @@ class ImportStaticDataJob implements ShouldQueue
             'zul' => 'zu', // Zulu
         ];
 
-        // Variant language codes to skip during import
-        // These are regional variants/creoles that aren't needed
-        $skipVariantCodes = [
-            // 'gsw', (skip german swiss variant for example)
-        ];
+        // Regional variants that map to a parent alpha2 via $alpha3ToAlpha2.
+        // They may still get a locale, but must not overwrite the parent language record.
+        // Codes in config('rest-countries.separate_language_codes') are excluded from this list.
+        $skipVariantCodes = [];
+
+        $separateLanguageCodes = config('rest-countries.separate_language_codes', ['gsw']);
 
         try {
             Log::channel('daily')->info('Attempting to fetch data from REST Countries API...');
@@ -312,24 +312,35 @@ class ImportStaticDataJob implements ShouldQueue
                     if (! empty($countryData['languages'])) {
                         foreach ($countryData['languages'] as $code => $name) {
                             try {
-                                // Skip variant codes that aren't needed
-                                if (in_array($code, $skipVariantCodes)) {
-                                    Log::channel('daily')->info("Skipping variant language {$code} ({$name}) for country {$country->alpha2}");
-
-                                    continue;
-                                }
-
-                                $alpha2 = $alpha3ToAlpha2[$code] ?? $code;
+                                $alpha2 = in_array($code, $separateLanguageCodes, true)
+                                    ? $code
+                                    : ($alpha3ToAlpha2[$code] ?? $code);
                                 $nativeName = $nativeNamesMap[$alpha2] ?? $name;
+                                $isVariantCode = in_array($code, $skipVariantCodes, true)
+                                    && ! in_array($code, $separateLanguageCodes, true);
 
-                                $language = StaticLanguage::updateOrCreate(
-                                    ['alpha2' => $alpha2],
-                                    [
-                                        'alpha3_b' => $code,
-                                        'common_name' => $name,
-                                        'native_name' => $nativeName,
-                                    ]
-                                );
+                                if ($isVariantCode) {
+                                    $language = StaticLanguage::query()->where('alpha2', $alpha2)->first();
+
+                                    if ($language === null) {
+                                        Log::channel('daily')->info("Skipping variant language {$code} ({$name}) for country {$country->alpha2} — parent language {$alpha2} not imported yet");
+
+                                        continue;
+                                    }
+
+                                    $localeName = $language->common_name;
+                                } else {
+                                    $language = StaticLanguage::updateOrCreate(
+                                        ['alpha2' => $alpha2],
+                                        [
+                                            'alpha3_b' => $code,
+                                            'common_name' => $name,
+                                            'native_name' => $nativeName,
+                                        ]
+                                    );
+
+                                    $localeName = $name;
+                                }
 
                                 $locale = $alpha2.'_'.strtoupper($country->alpha2);
                                 StaticLocale::updateOrCreate(
@@ -339,7 +350,7 @@ class ImportStaticDataJob implements ShouldQueue
                                     ],
                                     [
                                         'locale' => $locale,
-                                        'name' => $name,
+                                        'name' => $localeName,
                                         'is_official_language' => true,
                                     ]
                                 );

--- a/packages/data/src/Models/StaticLanguage.php
+++ b/packages/data/src/Models/StaticLanguage.php
@@ -80,6 +80,7 @@ class StaticLanguage extends Model
             'pl' => 'pl', // Polish -> Poland
             'zh' => 'cn', // Chinese -> China
             'de' => 'de', // German -> Germany
+            'gsw' => 'ch', // Swiss German -> Switzerland
             'hi' => 'in', // Hindi -> India
             'ja' => 'jp', // Japanese -> Japan
             'ko' => 'kr', // Korean -> South Korea

--- a/packages/data/tests/Feature/ImportStaticDataTest.php
+++ b/packages/data/tests/Feature/ImportStaticDataTest.php
@@ -68,3 +68,74 @@ test('import static data job imports countries using authenticated rest countrie
             && $request->hasHeader('Authorization', 'Bearer test-api-key');
     });
 });
+
+test('import static data job keeps german and swiss german as separate language records', function (): void {
+    Http::fake([
+        'api.restcountries.com/countries/v5*' => Http::response([
+            'data' => [
+                'objects' => [
+                    [
+                        'names' => ['common' => 'Germany', 'native' => [], 'alternates' => [], 'translations' => []],
+                        'codes' => ['alpha_2' => 'DE', 'alpha_3' => 'DEU'],
+                        'region' => 'Europe',
+                        'subregion' => 'Western Europe',
+                        'capitals' => [['name' => 'Berlin']],
+                        'population' => 83200000,
+                        'area' => ['kilometers' => 357114],
+                        'currencies' => [],
+                        'languages' => [['iso639_3' => 'deu', 'name' => 'German']],
+                        'timezones' => [],
+                        'calling_codes' => ['49'],
+                        'tlds' => ['.de'],
+                        'memberships' => [],
+                        'postal_code' => ['format' => null, 'regex' => null],
+                    ],
+                    [
+                        'names' => ['common' => 'Switzerland', 'native' => [], 'alternates' => [], 'translations' => []],
+                        'codes' => ['alpha_2' => 'CH', 'alpha_3' => 'CHE'],
+                        'region' => 'Europe',
+                        'subregion' => 'Western Europe',
+                        'capitals' => [['name' => 'Bern']],
+                        'population' => 8700000,
+                        'area' => ['kilometers' => 41284],
+                        'currencies' => [],
+                        'languages' => [
+                            ['iso639_3' => 'gsw', 'name' => 'Swiss German'],
+                            ['iso639_3' => 'deu', 'name' => 'German'],
+                        ],
+                        'timezones' => [],
+                        'calling_codes' => ['41'],
+                        'tlds' => ['.ch'],
+                        'memberships' => [],
+                        'postal_code' => ['format' => null, 'regex' => null],
+                    ],
+                ],
+                'meta' => [
+                    'total' => 2,
+                    'count' => 2,
+                    'limit' => 100,
+                    'offset' => 0,
+                    'more' => false,
+                ],
+            ],
+        ]),
+        'www.apicountries.com/*' => Http::response([
+            ['alpha2Code' => 'DE', 'languages' => [['iso639_1' => 'de', 'nativeName' => 'Deutsch']]],
+        ]),
+    ]);
+
+    (new ImportStaticDataJob)->handle();
+
+    $german = \Moox\Data\Models\StaticLanguage::query()->where('alpha2', 'de')->first();
+    $swissGerman = \Moox\Data\Models\StaticLanguage::query()->where('alpha2', 'gsw')->first();
+
+    expect($german)->not->toBeNull()
+        ->and($german->common_name)->toBe('German')
+        ->and($german->alpha3_b)->toBe('deu')
+        ->and($german->native_name)->toBe('Deutsch')
+        ->and($swissGerman)->not->toBeNull()
+        ->and($swissGerman->common_name)->toBe('Swiss German')
+        ->and($swissGerman->alpha3_b)->toBe('gsw')
+        ->and(\Moox\Data\Models\StaticLocale::query()->where('locale', 'de_CH')->value('name'))->toBe('German')
+        ->and(\Moox\Data\Models\StaticLocale::query()->where('locale', 'gsw_CH')->value('name'))->toBe('Swiss German');
+});


### PR DESCRIPTION
## Summary
- Fixes REST Countries static data import where Swiss German (`gsw`) was collapsed into German (`de`), causing either German to display as "Swiss German" or Swiss German to disappear from the Languages admin.
- Adds `separate_language_codes` to `config/rest-countries.php` (defaults to `['gsw']`) so configured ISO 639-3 variants import as their own `static_languages` row instead of overwriting a parent language.
- Keeps German and Swiss German as separate records with distinct locales (`de_CH` and `gsw_CH` for Switzerland when both are present in the API).
- Adds a flag mapping for `gsw` and a regression test covering Germany + Switzerland import.
