### PR TITLE
Fix missing Eloquent Model import in StaticUnitResource

### DIFF
--- a/packages/data/src/Filament/Resources/StaticUnitResource.php
+++ b/packages/data/src/Filament/Resources/StaticUnitResource.php
@@ -12,6 +12,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Moox\Core\Entities\Items\Static\BaseStaticResource;
 use Moox\Data\Filament\Resources\StaticUnitResource\Pages\CreateStaticUnit;
 use Moox\Data\Filament\Resources\StaticUnitResource\Pages\EditStaticUnit;


### PR DESCRIPTION
## Summary
- Add missing `use Illuminate\Database\Eloquent\Model` so `getRecordTitle(?Model $record)` resolves correctly and no longer fatals on class load / `php artisan boost:install`.

## Test plan
- [x] Confirm `packages/data/src/Filament/Resources/StaticUnitResource.php` loads without the fatal inheritance error
- [x] Re-run `php artisan boost:install` (or any artisan command that boots Filament resources)


Made with [Cursor](https://cursor.com)