### PR TITLE
fix UnitCodeResolver and DocumentTypeCodeResolver selecting translated common_name from parent tables

### DIFF
--- a/packages/e-billing/CHANGELOG.md
+++ b/packages/e-billing/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- `UnitCodeResolver` and `DocumentTypeCodeResolver` no longer select translated `common_name` from the parent static tables (column lives on `*_translations` after the Astrotomic move). They eager-load translations and index all locale labels instead.
 - Declare `"php": "^8.4"` in `composer.json`. Zugferd adapters (and `moox/zugferd` contracts) use PHP 8.4 property hooks; without an explicit constraint the package inherited `moox/core`'s `^8.2|^8.3|^8.4` and advertised runtimes that fatal-parse on load ([#11](https://github.com/mooxphp/e-billing/issues/11)).
 - SonarQube line-length (120 cols) and brace-placement findings in the
   generate-then-validate pipeline files, `InvoiceResource`,

--- a/packages/e-billing/src/Support/DocumentTypeCodeResolver.php
+++ b/packages/e-billing/src/Support/DocumentTypeCodeResolver.php
@@ -166,8 +166,9 @@ final class DocumentTypeCodeResolver
         }
 
         $records = StaticDocumentType::query()
+            ->with('translations')
             ->orderBy('code')
-            ->get(['code', 'common_name']);
+            ->get(['id', 'code']);
 
         if ($records->isEmpty()) {
             throw new CodelistNotImportedException('static_document_types');
@@ -179,18 +180,24 @@ final class DocumentTypeCodeResolver
 
         foreach ($records as $record) {
             $code = (string) $record->code;
-            $labelCandidates = array_filter([
-                mb_strtolower((string) $record->common_name),
+            $translatedNames = $record->translations
+                ->pluck('common_name')
+                ->filter(static fn (mixed $name): bool => is_string($name) && $name !== '')
+                ->map(static fn (string $name): string => mb_strtolower($name))
+                ->all();
+
+            $labelCandidates = array_values(array_unique(array_filter([
+                ...$translatedNames,
                 mb_strtolower(__('data::enums/document-types.'.$code, [], 'de')),
                 mb_strtolower(__('data::enums/document-types.'.$code, [], 'en')),
-            ]);
+            ])));
 
             $labels[$code] = __('data::enums/document-types.'.$code, [], 'de');
             if ($labels[$code] === 'data::enums/document-types.'.$code) {
-                $labels[$code] = (string) $record->common_name;
+                $labels[$code] = (string) ($record->translatedLabel('de') ?? $record->translatedLabel('en') ?? $code);
             }
 
-            $contains[$code] = array_values(array_unique($labelCandidates));
+            $contains[$code] = $labelCandidates;
 
             foreach ($labelCandidates as $candidate) {
                 if ($candidate === '') {

--- a/packages/e-billing/src/Support/UnitCodeResolver.php
+++ b/packages/e-billing/src/Support/UnitCodeResolver.php
@@ -63,8 +63,9 @@ final class UnitCodeResolver
         }
 
         $records = StaticUnit::query()
+            ->with('translations')
             ->orderBy('code')
-            ->get(['code', 'common_name', 'symbol']);
+            ->get(['id', 'code', 'symbol']);
 
         if ($records->isEmpty()) {
             throw new CodelistNotImportedException('static_units');
@@ -100,19 +101,25 @@ final class UnitCodeResolver
     {
         $code = (string) $record->code;
 
-        return array_values(array_filter([
-            mb_strtolower((string) $record->common_name),
+        $translatedNames = $record->translations
+            ->pluck('common_name')
+            ->filter(static fn (mixed $name): bool => is_string($name) && $name !== '')
+            ->map(static fn (string $name): string => mb_strtolower($name))
+            ->all();
+
+        return array_values(array_unique(array_filter([
+            ...$translatedNames,
             mb_strtolower((string) ($record->symbol ?? '')),
             mb_strtolower(__('data::enums/units.'.$code, [], 'de')),
             mb_strtolower(__('data::enums/units.'.$code, [], 'en')),
-        ]));
+        ])));
     }
 
     private function unitDisplayLabel(StaticUnit $record, string $code): string
     {
         $label = __('data::enums/units.'.$code, [], 'de');
         if ($label === 'data::enums/units.'.$code) {
-            return (string) $record->common_name;
+            return (string) ($record->translatedLabel('de') ?? $record->translatedLabel('en') ?? $code);
         }
 
         return $label;

--- a/packages/e-billing/tests/Unit/UnitCodeResolverTest.php
+++ b/packages/e-billing/tests/Unit/UnitCodeResolverTest.php
@@ -37,7 +37,7 @@ test('resolving many unit labels issues only one codelist query', function (): v
 
     $unitQueries = array_values(array_filter(
         DB::getQueryLog(),
-        fn (array $query): bool => str_contains($query['query'], 'static_units'),
+        fn (array $query): bool => (bool) preg_match('/\bfrom [`"]?static_units[`"]?\b/i', $query['query']),
     ));
 
     expect($unitQueries)->toHaveCount(1);


### PR DESCRIPTION
## Summary
- Stop selecting `common_name` from `static_units` / `static_document_types` after the Astrotomic move (column is on `*_translations`).
- Eager-load translations and index all locale labels in `UnitCodeResolver` and `DocumentTypeCodeResolver`.
- Tighten the unit resolver query-count assertion so `static_unit_translations` is not mistaken for `static_units`.