### PR TITLE
feat: add is_active toggle to company, contact, department, and staff

### DIFF
--- a/packages/company/config/company.php
+++ b/packages/company/config/company.php
@@ -49,9 +49,9 @@ return [
                     'icon' => 'gmdi-check-circle-o',
                     'query' => [
                         [
-                            'field' => 'status',
+                            'field' => 'is_active',
                             'operator' => '=',
-                            'value' => 'active',
+                            'value' => true,
                         ],
                         [
                             'field' => 'deleted_at',

--- a/packages/company/database/Factories/CompanyFactory.php
+++ b/packages/company/database/Factories/CompanyFactory.php
@@ -23,6 +23,7 @@ class CompanyFactory extends Factory
 
         return [
             'status' => fake()->randomElement(config('company.statuses', ['draft', 'active'])),
+            'is_active' => true,
             'name' => $name,
             'display_name' => $name,
             'legal_name' => fake()->optional(0.6)->company().' '.fake()->randomElement(['GmbH', 'AG', 'KG', 'OHG', 'Ltd.']),
@@ -51,6 +52,7 @@ class CompanyFactory extends Factory
     public function inactive(): static
     {
         return $this->state(fn (): array => [
+            'is_active' => false,
             'status' => 'inactive',
         ]);
     }

--- a/packages/company/database/migrations/create_companies_table.php.stub
+++ b/packages/company/database/migrations/create_companies_table.php.stub
@@ -13,6 +13,7 @@ return new class extends Migration
         Schema::create('companies', function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->string('status', 30)->default('draft')->index();
+            $table->boolean('is_active')->default(true)->index();
 
             $table->string('name', 120)->nullable()->index();
             $table->string('display_name', 120)->nullable();

--- a/packages/company/resources/lang/de/fields.php
+++ b/packages/company/resources/lang/de/fields.php
@@ -26,6 +26,7 @@ return [
     'contact' => 'Kontakt',
     'tax' => 'Steuer & Register',
     'settings' => 'Einstellungen',
+    'is_active' => 'Aktiv',
     'active' => 'Aktiv',
     'customers' => 'Kunden',
     'suppliers' => 'Lieferanten',

--- a/packages/company/resources/lang/en/fields.php
+++ b/packages/company/resources/lang/en/fields.php
@@ -26,6 +26,7 @@ return [
     'contact' => 'Contact',
     'tax' => 'Tax & registration',
     'settings' => 'Settings',
+    'is_active' => 'Active',
     'active' => 'Active',
     'customers' => 'Customers',
     'suppliers' => 'Suppliers',

--- a/packages/company/src/Models/Company.php
+++ b/packages/company/src/Models/Company.php
@@ -38,6 +38,7 @@ class Company extends BaseRecordModel
 
     protected $fillable = [
         'status',
+        'is_active',
         'name',
         'display_name',
         'legal_name',
@@ -61,6 +62,7 @@ class Company extends BaseRecordModel
     protected function casts(): array
     {
         return [
+            'is_active' => 'boolean',
             'language_id' => 'integer',
             'data' => 'array',
         ];

--- a/packages/company/src/Resources/CompanyResource.php
+++ b/packages/company/src/Resources/CompanyResource.php
@@ -7,11 +7,14 @@ namespace Moox\Company\Resources;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Moox\Company\Models\Company;
 use Moox\Company\Resources\Company\Pages\CreateCompany;
@@ -164,6 +167,9 @@ class CompanyResource extends BaseRecordResource
                                         ->searchable()
                                         ->preload()
                                         ->rules(CompanyRules::for('language_id')),
+                                    Toggle::make('is_active')
+                                        ->label(__('company::fields.is_active'))
+                                        ->default(true),
                                 ]),
                             Section::make('')
                                 ->schema($taxonomyFields),
@@ -210,6 +216,9 @@ class CompanyResource extends BaseRecordResource
                     }
                 )
                 ->sortable(),
+            IconColumn::make('is_active')
+                ->label(__('company::fields.is_active'))
+                ->boolean(),
         ];
 
         if ($hasParentRelation) {
@@ -263,7 +272,7 @@ class CompanyResource extends BaseRecordResource
     }
 
     /**
-     * @return array<SelectFilter>
+     * @return array<SelectFilter|TernaryFilter>
      */
     protected static function getCompanyTableFilters(): array
     {
@@ -271,6 +280,8 @@ class CompanyResource extends BaseRecordResource
             SelectFilter::make('status')
                 ->label(__('company::fields.status'))
                 ->options(static::configOptions('company.statuses')),
+            TernaryFilter::make('is_active')
+                ->label(__('company::fields.is_active')),
         ];
     }
 

--- a/packages/company/src/Support/CompanyRules.php
+++ b/packages/company/src/Support/CompanyRules.php
@@ -13,6 +13,7 @@ final class CompanyRules
     {
         return [
             'status' => ['required', 'string', 'max:30', 'in:'.implode(',', config('company.statuses', ['draft']))],
+            'is_active' => ['boolean'],
             'name' => ['nullable', 'string', 'max:120'],
             'display_name' => ['nullable', 'string', 'max:120'],
             'legal_name' => ['nullable', 'string', 'max:120'],

--- a/packages/contact/config/contact.php
+++ b/packages/contact/config/contact.php
@@ -60,9 +60,9 @@ return [
                     'icon' => 'gmdi-check-circle-o',
                     'query' => [
                         [
-                            'field' => 'status',
+                            'field' => 'is_active',
                             'operator' => '=',
-                            'value' => 'active',
+                            'value' => true,
                         ],
                         [
                             'field' => 'deleted_at',

--- a/packages/contact/database/Factories/ContactFactory.php
+++ b/packages/contact/database/Factories/ContactFactory.php
@@ -41,6 +41,7 @@ class ContactFactory extends Factory
             'password' => null,
             'contact_type' => fake()->randomElement(config('contact.contact_types', ['external'])),
             'language_id' => null,
+            'is_active' => true,
             'data' => null,
         ];
     }
@@ -55,6 +56,7 @@ class ContactFactory extends Factory
     public function inactive(): static
     {
         return $this->state(fn (): array => [
+            'is_active' => false,
             'status' => 'inactive',
         ]);
     }
@@ -63,6 +65,7 @@ class ContactFactory extends Factory
     {
         return $this->state(fn (): array => [
             'status' => 'active',
+            'is_active' => true,
             'email' => fake()->unique()->safeEmail(),
             'username' => fake()->unique()->userName(),
             'email_verified_at' => now(),

--- a/packages/contact/database/migrations/create_contacts_table.php.stub
+++ b/packages/contact/database/migrations/create_contacts_table.php.stub
@@ -13,6 +13,7 @@ return new class extends Migration
         Schema::create('contacts', function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->string('status', 30)->default('draft')->index();
+            $table->boolean('is_active')->default(true)->index();
 
             $table->string('gender', 20)->default('unknown')->index();
             $table->string('salutation_code', 30)->nullable()->index();

--- a/packages/contact/resources/lang/de/fields.php
+++ b/packages/contact/resources/lang/de/fields.php
@@ -30,5 +30,6 @@ return [
     'data' => 'Zusätzliche Daten',
     'identity' => 'Stammdaten',
     'contact' => 'Kontakt',
+    'is_active' => 'Aktiv',
     'active' => 'Aktiv',
 ];

--- a/packages/contact/resources/lang/en/fields.php
+++ b/packages/contact/resources/lang/en/fields.php
@@ -30,5 +30,6 @@ return [
     'data' => 'Additional data',
     'identity' => 'Identity',
     'contact' => 'Contact',
+    'is_active' => 'Active',
     'active' => 'Active',
 ];

--- a/packages/contact/src/Models/Contact.php
+++ b/packages/contact/src/Models/Contact.php
@@ -65,6 +65,7 @@ class Contact extends BaseRecordModel implements AuthenticatableContract, Author
         'contact_type',
         'note',
         'external_reference',
+        'is_active',
         'data',
         // Needed so transform field_map can persist soft-deletes via mass assignment.
         'deleted_at',
@@ -83,6 +84,7 @@ class Contact extends BaseRecordModel implements AuthenticatableContract, Author
             'language_id' => 'integer',
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_active' => 'boolean',
         ];
     }
 
@@ -122,7 +124,7 @@ class Contact extends BaseRecordModel implements AuthenticatableContract, Author
 
     public function canAccessPanel(Panel $panel): bool
     {
-        if (! $this->canAuthenticate() || $this->status !== 'active') {
+        if (! $this->canAuthenticate() || ! $this->is_active) {
             return false;
         }
 

--- a/packages/contact/src/Resources/ContactResource.php
+++ b/packages/contact/src/Resources/ContactResource.php
@@ -7,11 +7,14 @@ namespace Moox\Contact\Resources;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Moox\Contact\Models\Contact;
 use Moox\Contact\Resources\Contact\Pages\CreateContact;
@@ -172,6 +175,9 @@ class ContactResource extends BaseRecordResource
                                         ->searchable()
                                         ->preload()
                                         ->rules(ContactRules::for('language_id')),
+                                    Toggle::make('is_active')
+                                        ->label(__('contact::fields.is_active'))
+                                        ->default(true),
                                 ]),
                             Section::make('')
                                 ->schema($taxonomyFields),
@@ -241,6 +247,9 @@ class ContactResource extends BaseRecordResource
                 TextColumn::make('job_title')
                     ->label(__('contact::fields.job_title'))
                     ->toggleable(isToggledHiddenByDefault: true),
+                IconColumn::make('is_active')
+                    ->label(__('contact::fields.is_active'))
+                    ->boolean(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
@@ -259,7 +268,7 @@ class ContactResource extends BaseRecordResource
     }
 
     /**
-     * @return array<SelectFilter>
+     * @return array<SelectFilter|TernaryFilter>
      */
     protected static function getContactTableFilters(): array
     {
@@ -267,6 +276,8 @@ class ContactResource extends BaseRecordResource
             SelectFilter::make('status')
                 ->label(__('contact::fields.status'))
                 ->options(static::configOptions('contact.statuses')),
+            TernaryFilter::make('is_active')
+                ->label(__('contact::fields.is_active')),
             SelectFilter::make('contact_type')
                 ->label(__('contact::fields.contact_type'))
                 ->options(static::configOptions('contact.contact_types')),

--- a/packages/contact/src/Resources/ContactResource.php
+++ b/packages/contact/src/Resources/ContactResource.php
@@ -115,7 +115,9 @@ class ContactResource extends BaseRecordResource
                             Select::make('gender')
                                 ->label(__('contact::fields.gender'))
                                 ->options(static::configOptions('contact.genders'))
-                                ->rules(ContactRules::for('gender')),
+                                ->required()
+                                ->rules(ContactRules::for('gender'))
+                                ->default('unknown'),
                             TextInput::make('external_reference')
                                 ->label(__('contact::fields.external_reference'))
                                 ->rules(ContactRules::for('external_reference'))

--- a/packages/contact/src/Support/ContactRules.php
+++ b/packages/contact/src/Support/ContactRules.php
@@ -11,7 +11,7 @@ final class ContactRules
     {
         return [
             'status' => ['required', 'string', 'max:30', 'in:'.implode(',', config('contact.statuses', ['draft']))],
-            'gender' => ['nullable', 'string', 'max:20', 'in:'.implode(',', config('contact.genders', ['unknown']))],
+            'gender' => ['required', 'string', 'max:20', 'in:'.implode(',', config('contact.genders', ['unknown']))],
             'salutation_code' => ['nullable', 'string', 'max:30'],
             'academic_title' => ['nullable', 'string', 'max:80'],
             'first_name' => ['nullable', 'string', 'max:80'],

--- a/packages/contact/src/Support/ContactRules.php
+++ b/packages/contact/src/Support/ContactRules.php
@@ -27,6 +27,7 @@ final class ContactRules
             'contact_type' => ['required', 'string', 'max:30', 'in:'.implode(',', config('contact.contact_types', ['external']))],
             'note' => ['nullable', 'string'],
             'external_reference' => ['nullable', 'string', 'max:100'],
+            'is_active' => ['boolean'],
             'data' => ['nullable', 'array'],
         ];
     }

--- a/packages/contact/tests/Unit/ContactAuthTest.php
+++ b/packages/contact/tests/Unit/ContactAuthTest.php
@@ -31,7 +31,7 @@ it('is a filament user for non-admin panels when active and authenticatable', fu
 
 it('cannot access filament panels without credentials or when inactive', function (): void {
     $withoutPassword = Contact::factory()->create([
-        'status' => 'active',
+        'is_active' => true,
         'username' => 'active.user',
         'email' => 'active@example.com',
         'password' => null,

--- a/packages/customer/config/customer.php
+++ b/packages/customer/config/customer.php
@@ -88,9 +88,9 @@ return [
                     'icon' => 'gmdi-check-circle-o',
                     'query' => [
                         [
-                            'field' => 'status',
+                            'field' => 'is_active',
                             'operator' => '=',
-                            'value' => 'active',
+                            'value' => true,
                         ],
                         [
                             'field' => 'deleted_at',

--- a/packages/department/config/department.php
+++ b/packages/department/config/department.php
@@ -72,9 +72,9 @@ return [
                     'icon' => 'gmdi-check-circle-o',
                     'query' => [
                         [
-                            'field' => 'status',
+                            'field' => 'is_active',
                             'operator' => '=',
-                            'value' => 'active',
+                            'value' => true,
                         ],
                         [
                             'field' => 'deleted_at',

--- a/packages/department/database/Factories/DepartmentFactory.php
+++ b/packages/department/database/Factories/DepartmentFactory.php
@@ -23,6 +23,7 @@ class DepartmentFactory extends Factory
 
         return [
             'status' => fake()->randomElement(config('department.statuses', ['draft', 'active'])),
+            'is_active' => true,
             'name' => $name,
             'code' => strtoupper(fake()->unique()->bothify('DEP-###')),
             'description' => fake()->optional(0.4)->sentence(),
@@ -41,6 +42,7 @@ class DepartmentFactory extends Factory
     public function inactive(): static
     {
         return $this->state(fn (): array => [
+            'is_active' => false,
             'status' => 'inactive',
         ]);
     }

--- a/packages/department/database/migrations/create_departments_table.php.stub
+++ b/packages/department/database/migrations/create_departments_table.php.stub
@@ -13,6 +13,7 @@ return new class extends Migration
         Schema::create('departments', function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->string('status', 30)->default('draft')->index();
+            $table->boolean('is_active')->default(true)->index();
             $table->string('name', 160)->index();
             $table->string('code', 40)->nullable()->index();
             $table->text('description')->nullable();

--- a/packages/department/src/Models/Department.php
+++ b/packages/department/src/Models/Department.php
@@ -31,6 +31,7 @@ class Department extends BaseRecordModel
 
     protected $fillable = [
         'status',
+        'is_active',
         'name',
         'code',
         'description',
@@ -42,6 +43,7 @@ class Department extends BaseRecordModel
     protected function casts(): array
     {
         return [
+            'is_active' => 'boolean',
             'data' => 'array',
         ];
     }

--- a/packages/department/src/Resources/DepartmentResource.php
+++ b/packages/department/src/Resources/DepartmentResource.php
@@ -7,11 +7,14 @@ namespace Moox\Department\Resources;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Moox\Core\Entities\Items\Record\BaseRecordResource;
 use Moox\Core\Traits\Tabs\HasResourceTabs;
@@ -78,6 +81,9 @@ class DepartmentResource extends BaseRecordResource
                                 ->required()
                                 ->rules(DepartmentRules::for('status'))
                                 ->default('draft'),
+                            Toggle::make('is_active')
+                                ->label(__('department::fields.is_active'))
+                                ->default(true),
                             TextInput::make('name')
                                 ->label(__('department::fields.name'))
                                 ->required()
@@ -158,6 +164,9 @@ class DepartmentResource extends BaseRecordResource
                         }
                     )
                     ->sortable(),
+                IconColumn::make('is_active')
+                    ->label(__('department::fields.is_active'))
+                    ->boolean(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
@@ -176,7 +185,7 @@ class DepartmentResource extends BaseRecordResource
     }
 
     /**
-     * @return array<SelectFilter>
+     * @return array<SelectFilter|TernaryFilter>
      */
     protected static function getDepartmentTableFilters(): array
     {
@@ -184,6 +193,8 @@ class DepartmentResource extends BaseRecordResource
             SelectFilter::make('status')
                 ->label(__('department::fields.status'))
                 ->options(static::configOptions('department.statuses')),
+            TernaryFilter::make('is_active')
+                ->label(__('department::fields.is_active')),
         ];
     }
 

--- a/packages/department/src/Support/DepartmentRules.php
+++ b/packages/department/src/Support/DepartmentRules.php
@@ -11,6 +11,7 @@ final class DepartmentRules
     {
         return [
             'status' => ['required', 'string', 'max:30', 'in:'.implode(',', config('department.statuses', ['draft']))],
+            'is_active' => ['boolean'],
             'name' => ['required', 'string', 'max:160'],
             'code' => ['nullable', 'string', 'max:40'],
             'description' => ['nullable', 'string'],

--- a/packages/staff/config/staff.php
+++ b/packages/staff/config/staff.php
@@ -111,9 +111,9 @@ return [
                     'icon' => 'gmdi-check-circle-o',
                     'query' => [
                         [
-                            'field' => 'status',
+                            'field' => 'is_active',
                             'operator' => '=',
-                            'value' => 'active',
+                            'value' => true,
                         ],
                         [
                             'field' => 'deleted_at',

--- a/packages/staff/database/Factories/StaffFactory.php
+++ b/packages/staff/database/Factories/StaffFactory.php
@@ -36,6 +36,7 @@ class StaffFactory extends Factory
             'language_id' => null,
             'contact_id' => null,
             'is_internal' => true,
+            'is_active' => true,
             'data' => null,
         ];
     }
@@ -43,6 +44,7 @@ class StaffFactory extends Factory
     public function inactive(): static
     {
         return $this->state(fn (): array => [
+            'is_active' => false,
             'status' => 'inactive',
         ]);
     }

--- a/packages/staff/database/migrations/create_staff_table.php.stub
+++ b/packages/staff/database/migrations/create_staff_table.php.stub
@@ -25,6 +25,7 @@ return new class extends Migration
             $table->foreignId('language_id')->nullable()->constrained('static_languages')->nullOnDelete();
             $table->uuid('contact_id')->nullable()->index();
             $table->boolean('is_internal')->default(true)->index();
+            $table->boolean('is_active')->default(true)->index();
             $table->json('data')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/packages/staff/resources/lang/de/fields.php
+++ b/packages/staff/resources/lang/de/fields.php
@@ -21,6 +21,7 @@ return [
     'is_primary' => 'Primär',
     'role' => 'Rolle',
     'is_internal' => 'Intern',
+    'is_active' => 'Aktiv',
     'active' => 'Aktiv',
     'internal' => 'Intern',
     'identity' => 'Stammdaten',

--- a/packages/staff/resources/lang/en/fields.php
+++ b/packages/staff/resources/lang/en/fields.php
@@ -21,6 +21,7 @@ return [
     'is_primary' => 'Primary',
     'role' => 'Role',
     'is_internal' => 'Internal',
+    'is_active' => 'Active',
     'active' => 'Active',
     'internal' => 'Internal',
     'identity' => 'Identity',

--- a/packages/staff/src/Models/Staff.php
+++ b/packages/staff/src/Models/Staff.php
@@ -51,6 +51,7 @@ class Staff extends BaseRecordModel implements HasMedia
         'language_id',
         'contact_id',
         'is_internal',
+        'is_active',
         'data',
     ];
 
@@ -61,6 +62,7 @@ class Staff extends BaseRecordModel implements HasMedia
             'legacy_id' => 'integer',
             'language_id' => 'integer',
             'is_internal' => 'boolean',
+            'is_active' => 'boolean',
             'data' => 'array',
         ];
     }

--- a/packages/staff/src/Resources/StaffResource.php
+++ b/packages/staff/src/Resources/StaffResource.php
@@ -127,6 +127,9 @@ class StaffResource extends BaseRecordResource
                                     Toggle::make('is_internal')
                                         ->label(__('staff::fields.is_internal'))
                                         ->default(true),
+                                    Toggle::make('is_active')
+                                        ->label(__('staff::fields.is_active'))
+                                        ->default(true),
                                 ]),
                             Section::make('')
                                 ->schema($taxonomyFields),
@@ -240,6 +243,9 @@ class StaffResource extends BaseRecordResource
                     ->label(__('staff::fields.is_internal'))
                     ->boolean()
                     ->toggleable(isToggledHiddenByDefault: true),
+                IconColumn::make('is_active')
+                    ->label(__('staff::fields.is_active'))
+                    ->boolean(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
@@ -268,6 +274,8 @@ class StaffResource extends BaseRecordResource
                 ->options(static::configOptions('staff.statuses')),
             TernaryFilter::make('is_internal')
                 ->label(__('staff::fields.is_internal')),
+            TernaryFilter::make('is_active')
+                ->label(__('staff::fields.is_active')),
         ];
     }
 

--- a/packages/staff/src/Support/StaffRules.php
+++ b/packages/staff/src/Support/StaffRules.php
@@ -23,6 +23,7 @@ final class StaffRules
             'language_id' => ['nullable', 'integer', 'exists:static_languages,id'],
             'contact_id' => ['nullable', 'uuid'],
             'is_internal' => ['boolean'],
+            'is_active' => ['boolean'],
             'data' => ['nullable', 'array'],
         ];
     }


### PR DESCRIPTION
## Summary
- Add boolean `is_active` (default `true`, indexed) to **company**, **contact**, **department**, and **staff**, matching customer/supplier.
- Filament: Active toggle, table icon column, ternary filter; Active tabs query `is_active = true` (not `status = active`).
- Contact portal access (`canAccessPanel`) now requires `is_active` instead of `status === 'active'`.
- Align customer Active tab with `is_active`.
- Require contact `gender` on create/edit (DB is NOT NULL); default `unknown`.

## Packages
- `moox/company`
- `moox/contact`
- `moox/department`
- `moox/staff`
- `moox/customer` (Active tab only)

## Notes
- Workflow `status` (including `active`) is unchanged and remains separate from the toggle.

## Test plan
- [x] Create company/contact/department/staff with Active toggle on/off; confirm Active tab lists only `is_active = true`
- [x] Contact: portal login denied when `is_active` is off (even with username/password)
- [x] Contact: portal login allowed when `is_active` is on and credentials are set
- [x] Contact: create without gender fails validation; default `unknown` on new form
- [x] Run `packages/contact` unit tests (`ContactAuthTest`)
- [x] Confirm `status` Select / filters still work independently of `is_active`