### PR TITLE
feat(transform): add raw where clause operator for db table sources

### DIFF
--- a/packages/transform/src/Support/DbTableSourceQuery.php
+++ b/packages/transform/src/Support/DbTableSourceQuery.php
@@ -50,6 +50,23 @@ final class DbTableSourceQuery
     {
         $operator = strtolower((string) ($clause['operator'] ?? '='));
 
+        if ($operator === 'raw' && is_array($clause['value'] ?? null)) {
+            $sql = $clause['value']['sql'] ?? null;
+            $bindings = $clause['value']['bindings'] ?? [];
+
+            if (! is_string($sql) || $sql === '') {
+                return;
+            }
+
+            if (! is_array($bindings)) {
+                $bindings = [];
+            }
+
+            $or ? $query->orWhereRaw($sql, $bindings) : $query->whereRaw($sql, $bindings);
+
+            return;
+        }
+
         if ($operator === 'or' && is_array($clause['value'] ?? null)) {
             $callback = function (Builder $nested) use ($clause): void {
                 $subClauses = array_values(array_filter(
@@ -132,7 +149,7 @@ final class DbTableSourceQuery
         }
 
         if ($operator === 'datetime_gte' && array_key_exists('value', $clause)) {
-            self::applyDateTimeGteClause($query, $column, $clause['value'], $or);
+            $or ? $query->orWhere($column, '>=', $clause['value']) : $query->where($column, '>=', $clause['value']);
 
             return;
         }
@@ -144,27 +161,6 @@ final class DbTableSourceQuery
         }
 
         $or ? $query->orWhere($column, $operator) : $query->where($column, $operator);
-    }
-
-    private static function applyDateTimeGteClause(Builder $query, string $column, mixed $value, bool $or = false): void
-    {
-        if ($query->getConnection()->getDriverName() === 'sqlsrv') {
-            $wrappedColumn = $query->getGrammar()->wrap($column);
-            $callback = static fn (Builder $builder): Builder => $builder->whereRaw(
-                "TRY_CONVERT(datetime, {$wrappedColumn}, 120) >= ?",
-                [$value],
-            );
-
-            if ($or) {
-                $query->orWhere($callback);
-            } else {
-                $query->where($callback);
-            }
-
-            return;
-        }
-
-        $or ? $query->orWhere($column, '>=', $value) : $query->where($column, '>=', $value);
     }
 
     public static function hasRowKey(mixed $rowKey): bool

--- a/packages/transform/tests/Unit/Support/DbTableSourceQueryTest.php
+++ b/packages/transform/tests/Unit/Support/DbTableSourceQueryTest.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Connection;
-use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -32,6 +29,36 @@ test('db table source query applies datetime_gte as greater-than-or-equal on def
                 'column' => 'changed_at',
                 'operator' => 'datetime_gte',
                 'value' => '2026-08-17 00:00:00',
+            ],
+        ],
+    ]);
+
+    expect($query->orderBy('id')->pluck('id')->all())->toBe([2]);
+
+    Schema::dropIfExists('db_table_source_rows');
+});
+
+test('db table source query applies raw where clauses with bindings', function (): void {
+    Schema::dropIfExists('db_table_source_rows');
+    Schema::create('db_table_source_rows', function (Blueprint $table): void {
+        $table->id();
+        $table->timestamp('changed_at')->nullable();
+    });
+
+    DB::table('db_table_source_rows')->insert([
+        ['id' => 1, 'changed_at' => '2026-08-10 00:00:00'],
+        ['id' => 2, 'changed_at' => '2026-08-18 00:00:00'],
+    ]);
+
+    $query = DB::table('db_table_source_rows');
+    DbTableSourceQuery::applyWhereClauses($query, [
+        'where' => [
+            [
+                'operator' => 'raw',
+                'value' => [
+                    'sql' => 'changed_at >= ?',
+                    'bindings' => ['2026-08-17 00:00:00'],
+                ],
             ],
         ],
     ]);
@@ -79,26 +106,4 @@ test('db table source query applies or groups for multi-column datetime cutoffs'
     expect($query->orderBy('id')->pluck('id')->all())->toBe([2, 3]);
 
     Schema::dropIfExists('db_table_source_rows');
-});
-
-test('db table source query uses try_convert for datetime_gte on sqlsrv', function (): void {
-    $connection = Mockery::mock(Connection::class);
-    $grammar = Mockery::mock(Grammar::class);
-    $builder = Mockery::mock(Builder::class);
-
-    $connection->shouldReceive('getDriverName')->once()->andReturn('sqlsrv');
-    $grammar->shouldReceive('wrap')->once()->with('changed_at')->andReturn('[changed_at]');
-    $builder->shouldReceive('getConnection')->once()->andReturn($connection);
-    $builder->shouldReceive('getGrammar')->once()->andReturn($grammar);
-    $builder->shouldReceive('where')->once()->with(Mockery::type('Closure'));
-
-    DbTableSourceQuery::applyWhereClauses($builder, [
-        'where' => [
-            [
-                'column' => 'changed_at',
-                'operator' => 'datetime_gte',
-                'value' => '2026-08-17 00:00:00',
-            ],
-        ],
-    ]);
 });


### PR DESCRIPTION
Allow consumers to pass parameterized SQL via source reference where clauses. Remove SQL Server-specific datetime_gte handling from the transform package.